### PR TITLE
Fix up Spanish translation of CUTGroup page

### DIFF
--- a/es.html
+++ b/es.html
@@ -17,7 +17,7 @@
 	<body>
 			<nav>
 				<ul>
-					<li><a href="#tester" class="scrolly">Sea n probador</a></li>
+					<li><a href="#tester" class="scrolly">Participe como probador</a></li>
 					<li><a href="#about" class="scrolly">Nosotros</a></li>
 					<li><a href="#contact" class="scrolly">Contacto</a></li>
 				</ul>
@@ -26,7 +26,7 @@
 			<section id="header">
 				<div class="inner">
 					<span class="icon major fa-cloud"></span>
-					<h1>Sea un probador, <strong>gane dinero</strong></h1>
+					<h1>Participe como probador y <strong>gane dinero</strong></h1>
 					<p>El Civic User Testing Group (CUTGroup) es una comunidad de residentes de Miami-Dade que se les paga para probar sitios web y aplicaciones civiles</p>
 					<ul class="actions">
 						<li><a href="#one" class="button scrolly">Como funciona</a></li>
@@ -42,7 +42,7 @@
 							<header class="major">
 								<h2>Si no funciona para usted,<br> no funciona!</h2>
 							</header>
-							<p>Buscamos a los residentes de todo Miami-Dade, que utilizan diferentes tipos de dispositivos, navegadores y sistemas operativos.</p>
+							<p>Buscamos a residentes de todo Miami-Dade, que utilizen diferentes tipos de dispositivos, navegadores y sistemas operativos.</p>
 							<p>Hay desarrolladores de tecnología que hacen sitios web, aplicaciones móviles y otras herramientas que se hacen específicamente para los residentes. Al ser parte de la CUTGroup va a ayudar a los desarrolladores hacer un mejor software que ayudará a hacer mejor la vida de otros.</p>
 							<ul>
 								<li>Llene el formulario de perfil CUTGroup abajo para inscribirse para ser un probador. Una vez hecho eso, le enviaremos una tarjeta de regalo de $ 5 VISA sólo por inscribirse


### PR DESCRIPTION
- Fix typo.
- Use consistent call to action.
- Use subjunctive where needed.
